### PR TITLE
Release 3.4.0

### DIFF
--- a/dist/wme-address-point-helper.user.js
+++ b/dist/wme-address-point-helper.user.js
@@ -83,8 +83,6 @@
                 drawArea: 'Создать контур',
                 drawNature: 'Создать природу',
                 drawParking: 'Создать парковку',
-                drawPoint: 'Создать точку',
-                createOther: 'Создать точку',
             },
             settings: {
                 title: 'Настройки',

--- a/dist/wme-address-point-helper.user.js
+++ b/dist/wme-address-point-helper.user.js
@@ -5,7 +5,7 @@
 // @description  Creates point with an address of the selected venue
 // @description:uk Створення точок з адресою обраного POI
 // @description:ru Создание точек с адресом выбранного POI
-// @version      3.3.0
+// @version      3.4.0
 // @license      MIT License
 // @author       Andrei Pavlenko, Anton Shevchuk
 // @namespace    https://greasyfork.org/users/160654-waze-ukraine

--- a/dist/wme-address-point-helper.user.js
+++ b/dist/wme-address-point-helper.user.js
@@ -5,7 +5,7 @@
 // @description  Creates point with an address of the selected venue
 // @description:uk Створення точок з адресою обраного POI
 // @description:ru Создание точек с адресом выбранного POI
-// @version      3.4.0
+// @version      3.4.1
 // @license      MIT License
 // @author       Andrei Pavlenko, Anton Shevchuk
 // @namespace    https://greasyfork.org/users/160654-waze-ukraine
@@ -18,8 +18,8 @@
 // @grant        none
 // @require      https://update.greasyfork.org/scripts/389765/1794584/CommonUtils.js
 // @require      https://update.greasyfork.org/scripts/450160/1792042/WME-Bootstrap.js
-// @require      https://update.greasyfork.org/scripts/450221/1793261/WME-Base.js
-// @require      https://update.greasyfork.org/scripts/450320/1794414/WME-UI.js
+// @require      https://update.greasyfork.org/scripts/450221/1804989/WME-Base.js
+// @require      https://update.greasyfork.org/scripts/450320/1796236/WME-UI.js
 // @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.2.0/turf.min.js
 // ==/UserScript==
 

--- a/dist/wme-address-point-helper.user.js
+++ b/dist/wme-address-point-helper.user.js
@@ -192,31 +192,25 @@
     function createResidential() {
         createPoint(true);
     }
-    /**
-     * Trigger WME's native "draw point venue" mode for "Other" category
-     * by simulating a click on the Place > Other > Point button in the toolbar menu
-     */
-    function drawOtherPoint() {
-        clickOtherButton('wz-button.point');
+    async function drawOtherPoint() {
+        const geometry = await APHInstance.wmeSDK.Map.drawPoint();
+        const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'OTHER', geometry });
+        APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } });
     }
-    function drawOtherArea() {
-        clickMenuButton('other.svg', 'wz-button.polygon');
+    async function drawOtherArea() {
+        const geometry = await APHInstance.wmeSDK.Map.drawPolygon();
+        const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'OTHER', geometry });
+        APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } });
     }
-    function drawNatureArea() {
-        clickMenuButton('natural-features.svg', 'wz-button.polygon');
+    async function drawNatureArea() {
+        const geometry = await APHInstance.wmeSDK.Map.drawPolygon();
+        const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'NATURAL_FEATURES', geometry });
+        APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } });
     }
-    function drawParkingArea() {
-        clickMenuButton('parking-lot.svg', 'wz-button.polygon');
-    }
-    function clickMenuButton(iconFile, selector) {
-        let icon = document.querySelector('wz-menu-item img[src*="' + iconFile + '"]');
-        if (icon) {
-            let menuItem = icon.closest('wz-menu-item');
-            let btn = menuItem?.querySelector(selector);
-            if (btn) {
-                btn.click();
-            }
-        }
+    async function drawParkingArea() {
+        const geometry = await APHInstance.wmeSDK.Map.drawPolygon();
+        const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'PARKING_LOT', geometry });
+        APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } });
     }
     function hasDuplicate(name, streetId, houseNumber, isResidential) {
         const venues = APHInstance.getAllVenues();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wme-address-point-helper",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c --watch"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wme-address-point-helper",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "scripts": {
     "build": "rollup -c",
     "watch": "rollup -c --watch"

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -115,35 +115,28 @@ export function createResidential() {
   createPoint(true)
 }
 
-/**
- * Trigger WME's native "draw point venue" mode for "Other" category
- * by simulating a click on the Place > Other > Point button in the toolbar menu
- */
-export function drawOtherPoint() {
-  clickOtherButton('wz-button.point')
+export async function drawOtherPoint() {
+  const geometry = await APHInstance.wmeSDK.Map.drawPoint()
+  const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'OTHER', geometry })
+  APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } })
 }
 
-export function drawOtherArea() {
-  clickMenuButton('other.svg', 'wz-button.polygon')
+export async function drawOtherArea() {
+  const geometry = await APHInstance.wmeSDK.Map.drawPolygon()
+  const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'OTHER', geometry })
+  APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } })
 }
 
-export function drawNatureArea() {
-  clickMenuButton('natural-features.svg', 'wz-button.polygon')
+export async function drawNatureArea() {
+  const geometry = await APHInstance.wmeSDK.Map.drawPolygon()
+  const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'NATURAL_FEATURES', geometry })
+  APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } })
 }
 
-export function drawParkingArea() {
-  clickMenuButton('parking-lot.svg', 'wz-button.polygon')
-}
-
-function clickMenuButton(iconFile: string, selector: string) {
-  let icon = document.querySelector('wz-menu-item img[src*="' + iconFile + '"]') as HTMLElement
-  if (icon) {
-    let menuItem = icon.closest('wz-menu-item')
-    let btn = menuItem?.querySelector(selector) as HTMLElement
-    if (btn) {
-      btn.click()
-    }
-  }
+export async function drawParkingArea() {
+  const geometry = await APHInstance.wmeSDK.Map.drawPolygon()
+  const venueId = APHInstance.wmeSDK.DataModel.Venues.addVenue({ category: 'PARKING_LOT', geometry })
+  APHInstance.wmeSDK.Editing.setSelection({ selection: { ids: [String(venueId)], objectType: 'venue' } })
 }
 
 export function hasDuplicate(name: any, streetId: any, houseNumber: any, isResidential: boolean) {

--- a/src/meta.ts
+++ b/src/meta.ts
@@ -18,7 +18,7 @@
 // @grant        none
 // @require      https://update.greasyfork.org/scripts/389765/1794584/CommonUtils.js
 // @require      https://update.greasyfork.org/scripts/450160/1792042/WME-Bootstrap.js
-// @require      https://update.greasyfork.org/scripts/450221/1793261/WME-Base.js
-// @require      https://update.greasyfork.org/scripts/450320/1794414/WME-UI.js
+// @require      https://update.greasyfork.org/scripts/450221/1804989/WME-Base.js
+// @require      https://update.greasyfork.org/scripts/450320/1796236/WME-UI.js
 // @require      https://cdn.jsdelivr.net/npm/@turf/turf@7.2.0/turf.min.js
 // ==/UserScript==

--- a/src/translations.ts
+++ b/src/translations.ts
@@ -53,8 +53,6 @@ export const TRANSLATION: Record<string, any> = {
       drawArea: 'Создать контур',
       drawNature: 'Создать природу',
       drawParking: 'Создать парковку',
-      drawPoint: 'Создать точку',
-      createOther: 'Создать точку',
     },
     settings: {
       title: 'Настройки',


### PR DESCRIPTION
## Summary

- **Draw shortcuts** — use SDK `drawPoint()` / `drawPolygon()` instead of DOM click simulation
  - `P` — Draw Point (Other category)
  - `Shift+L` — Draw Area (Other category)
  - `Shift+N` — Draw Area (Natural Features)
  - `Shift+P` — Draw Area (Parking Lot)
- Add description and help text to sidebar tab (en, uk, ru)
- Remove redundant CSS rules (now provided by wme-ui)
- Extract `NAME` to separate `name.ts`
- Remove `SimpleCache` from `globals.d.ts`
- Update `@require` URLs to latest library versions

Fixes #2

## Test plan

- [ ] Press `P` — verify crosshair cursor appears, click to place a point venue (Other)
- [ ] Press `Shift+L` — draw an area polygon (Other), verify venue is created
- [ ] Press `Shift+N` — draw a Natural Features polygon
- [ ] Press `Shift+P` — draw a Parking Lot polygon
- [ ] Press `Esc` during drawing — verify it cancels
- [ ] Select a venue — verify Clone to Point / Clone to Residential buttons in panel
- [ ] Test `Alt+G` and `Alt+H` shortcuts for cloning

🤖 Generated with [Claude Code](https://claude.com/claude-code)